### PR TITLE
Fixes to support Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,8 +39,8 @@ class firewalld2iptables (
 
   # Only run on systems known to have firewalld
   case $::osfamily {
-    RedHat : {
-      if ($::operatingsystemmajrelease == 7) {
+    'RedHat' : {
+      if ($::operatingsystemmajrelease == '7') {
         if ($manage_package) {
           package { 'iptables-services': ensure => $iptables_ensure, }
         }


### PR DESCRIPTION
Without these changes both of the tests fail silently. In Puppet 4 quoting is needed to make sure that comparisons are done between string values.
